### PR TITLE
Rectify Bugs in Quantum Circuit 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 dist
 *.egg-info/
 .pypirc
+__pycache__/

--- a/qcge/__init__.py
+++ b/qcge/__init__.py
@@ -1,1 +1,2 @@
 from qcge.quantum_circuit import QuantumCircuitGrid
+from qcge.configs import *

--- a/qcge/quantum_circuit.py
+++ b/qcge/quantum_circuit.py
@@ -3,7 +3,7 @@ from qiskit import QuantumRegister, QuantumCircuit
 import numpy as np
 
 from pygame.image import load as loadImage
-from configs import *
+from qcge.configs import *
 
 
 class QuantumCircuitGridBackground(pygame.sprite.Sprite):

--- a/qcge/quantum_circuit.py
+++ b/qcge/quantum_circuit.py
@@ -10,12 +10,12 @@ class QuantumCircuitGridBackground(pygame.sprite.Sprite):
     def __init__(self, qc_grid_model, background_color, wire_color, tile_size, wire_line_width):
         super().__init__()
         self.qc_grid_model = qc_grid_model
+        self.tile_size = tile_size 
+        self.wire_color = wire_color
+        self.wire_line_width = wire_line_width
+        self.background_color = background_color
         self.width = self.tile_size * (self.qc_grid_model.num_columns + 2)
         self.height = self.tile_size * (self.qc_grid_model.num_qubits + 1)
-        self.background_color = background_color
-        self.wire_color = wire_color
-        self.tile_size = tile_size
-        self.wire_line_width = wire_line_width
 
         # BACKGROUND SURFACE
         self.image = pygame.Surface((self.width, self.height))
@@ -311,7 +311,7 @@ class QuantumCircuitGrid(pygame.sprite.RenderPlain):
         self.current_column = 0
         
         self.qc_grid_model = QuantumCircuitGridModel(num_qubits, num_columns)
-        self.qc_grid_background = QuantumCircuitGridBackground(self.qc_grid_model, background_color=self.background_color, wire_color=self.wire_color, tile_size=self.tile_size)
+        self.qc_grid_background = QuantumCircuitGridBackground(self.qc_grid_model, background_color=self.background_color, wire_color=self.wire_color, tile_size=self.tile_size, wire_line_width=self.wire_line_width)
         self.qc_grid_marker = QuantumCircuitGridMarker()
 
         self.gate_tiles = np.zeros(


### PR DESCRIPTION
Hey @devilkiller-ag, I've been playing around with your project, andI've found some little problems in the code during the execution, so this PR tries to fix it.

---

## 1. `qcge.configs`

Every time that I've imported `qcge` it raised to me the following error:

```bash
ModuleNotFoundError: No module named 'configs'
```

I worked around and added the full import in `quantum_circuit.py` and also added it into the `__init__.py`, once someone may want to have more control in their project and use the configs to trigger some actions.

---

## 2. `QuantumCircuitGridBackground` arguments

the `QuantumCircuitGridBackground` was missing the `wire_line_width` argument, so I've just passed it.

---

## 3. `QuantumCircuitGridBackground` instance

once you've instanciated a `QuantumCircuitGridBackground` you were trying to multiply something by `self.tile_size`, but it was actually declared after it's call. So I've changed the declaration order.

---

## 4. `__pycache__`

I'm also added `__pycache__` to the `.gitignore` file, just to clean a little bit the repo.

---

After all, these all the little problems that I've found. Thank you so much for doing this project :)

 