### PR TITLE
Update setup.py to depend on qiskit directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     package_dir={"": "qcge"},
     packages=find_packages(where="qcge"),
     url="https://github.com/devilkiller-ag/Quantum-Circuit-Game-Engine",
-    install_requires=["pygame", "qiskit>=0.44", "numpy", "twine"],
+    install_requires=["pygame", "qiskit>=0.44,<1", "numpy", "twine"],
     keywords=["quantum circuit game engine", "quantum circuit pygame", "quantum circuit",
                 "qcge", "quantum game", "pygame"],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     package_dir={"": "qcge"},
     packages=find_packages(where="qcge"),
     url="https://github.com/devilkiller-ag/Quantum-Circuit-Game-Engine",
-    install_requires=["pygame", "qiskit-terra>=0.25.0", "numpy", "twine"],
+    install_requires=["pygame", "qiskit>=0.44", "numpy", "twine"],
     keywords=["quantum circuit game engine", "quantum circuit pygame", "quantum circuit",
                 "qcge", "quantum game", "pygame"],
     classifiers=[


### PR DESCRIPTION
Qiskit is moving away from the `qiskit` metapackage architecture after 1.0. `qiskit-terra` wont be maintained after August 2024.

`qiskit-terra>=0.25` is equivalent to`qiskit>=0.44,<1` 

Fixes #3
